### PR TITLE
Add new Alliance Integration to track

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/phonehome/enums/ThirdPartyName.java
+++ b/src/main/java/com/blackducksoftware/integration/phonehome/enums/ThirdPartyName.java
@@ -42,6 +42,7 @@ public enum ThirdPartyName {
     JIRA("Jira"),
     MAVEN("Maven"),
     NEXUS("Nexus"),
+    OSCF_SCANNER("Cloud Foundry Scan Service Broker"),
     PIVOTAL_SCANNER("Pivotal Scan Service Broker"),
     SBT("Scala Build Tool"),
     SONARQUBE("Sonarqube"),


### PR DESCRIPTION
Added "Open Source Cloud Foundry Scan Service Broker" (OCSF_SCANNER) to
list of Third Party Names so usage of the Open Source Cloud Foundry can
be tracked separately from other CF implementation (eg Pivotal)